### PR TITLE
Using time.Duration instead of time.Time for stat UNTESTED

### DIFF
--- a/stat/stat.go
+++ b/stat/stat.go
@@ -31,10 +31,10 @@ type Stat struct {
 	Cminflt             int64         // number of minor faults with child's
 	Majflt              int64         // number of major faults
 	Cmajflt             int64         // number of major faults with child's
-	Utime               time.Duration // user mode jiffies
-	Stime               time.Duration // kernel mode jiffies
-	Cutime              time.Duration // user mode jiffies with child's
-	Cstime              time.Duration // kernel mode jiffies with child's
+	Utime               time.Duration // user mode in nanoseconds
+	Stime               time.Duration // kernel mode in nanoseconds
+	Cutime              time.Duration // user mode in nanoseconds with child's
+	Cstime              time.Duration // kernel mode in nanoseconds with child's
 	Priority            int64         // priority level
 	Nice                int64         // nice level
 	NumThreads          int64         // number of threads

--- a/stat/stat.go
+++ b/stat/stat.go
@@ -8,57 +8,58 @@ package stat
 
 import (
 	"io/ioutil"
-	"github.com/jandre/procfs/util"
 	"strings"
 	"time"
+
+	"github.com/jandre/procfs/util"
 )
 
 //
 // Stat is a data structure that maps to /proc/<pid>/stat.
 //
 type Stat struct {
-	Pid                 int                 // process id
-	Comm                string              // filename of the executable
-	State               string              // state (R is running, S is sleeping, D is sleeping in an uninterruptible wait, Z is zombie, T is traced or stopped)
-	Ppid                int                 // process id of the parent process
-	Pgrp                int                 // pgrp of the process
-	Session             int                 // session id
-	TtyNr               int                 // tty the process uses
-	Tpgid               int                 // pgrp of the tty
-	Flags               int64               // task flags
-	Minflt              int64               // number of minor faults
-	Cminflt             int64               // number of minor faults with child's
-	Majflt              int64               // number of major faults
-	Cmajflt             int64               // number of major faults with child's
-	Utime               time.Time // user mode jiffies
-	Stime               time.Time // kernel mode jiffies
-	Cutime              time.Time // user mode jiffies with child's
-	Cstime              time.Time // kernel mode jiffies with child's
-	Priority            int64               // priority level
-	Nice                int64               // nice level
-	NumThreads          int64               // number of threads
-	Itrealvalue         int64               // (obsolete, always 0)
-	Starttime           time.Time // time the process started after system boot
-	Vsize               int64               // virtual memory size
-	Rss                 int64               // resident set memory size
-	Rlim                uint64              // current limit in bytes on the rss
-	Startcode           int64               // address above which program text can run
-	Endcode             int64               // address below which program text can run
-	Startstack          int64               // address of the start of the main process stack
-	Kstkesp             int64               // current value of ESP
-	Kstkeip             int64               // current value of EIP
-	Signal              int64               // bitmap of pending signals
-	Blocked             int64               // bitmap of blocked signals
-	Sigignore           int64               // bitmap of ignored signals
-	Sigcatch            int64               // bitmap of catched signals
-	Wchan               uint64              // address where process went to sleep
-	Nswap               int64               // (place holder)
-	Cnswap              int64               // (place holder)
-	ExitSignal          int                 // signal to send to parent thread on exit
-	Processor           int                 // which CPU the task is scheduled on
-	RtPriority          int64               // realtime priority
-	Policy              int64               // scheduling policy (man sched_setscheduler)
-	DelayacctBlkioTicks int64               // time spent waiting for block IO
+	Pid                 int           // process id
+	Comm                string        // filename of the executable
+	State               string        // state (R is running, S is sleeping, D is sleeping in an uninterruptible wait, Z is zombie, T is traced or stopped)
+	Ppid                int           // process id of the parent process
+	Pgrp                int           // pgrp of the process
+	Session             int           // session id
+	TtyNr               int           // tty the process uses
+	Tpgid               int           // pgrp of the tty
+	Flags               int64         // task flags
+	Minflt              int64         // number of minor faults
+	Cminflt             int64         // number of minor faults with child's
+	Majflt              int64         // number of major faults
+	Cmajflt             int64         // number of major faults with child's
+	Utime               time.Duration // user mode jiffies
+	Stime               time.Duration // kernel mode jiffies
+	Cutime              time.Duration // user mode jiffies with child's
+	Cstime              time.Duration // kernel mode jiffies with child's
+	Priority            int64         // priority level
+	Nice                int64         // nice level
+	NumThreads          int64         // number of threads
+	Itrealvalue         int64         // (obsolete, always 0)
+	Starttime           time.Time     // time the process started after system boot
+	Vsize               int64         // virtual memory size
+	Rss                 int64         // resident set memory size
+	Rlim                uint64        // current limit in bytes on the rss
+	Startcode           int64         // address above which program text can run
+	Endcode             int64         // address below which program text can run
+	Startstack          int64         // address of the start of the main process stack
+	Kstkesp             int64         // current value of ESP
+	Kstkeip             int64         // current value of EIP
+	Signal              int64         // bitmap of pending signals
+	Blocked             int64         // bitmap of blocked signals
+	Sigignore           int64         // bitmap of ignored signals
+	Sigcatch            int64         // bitmap of catched signals
+	Wchan               uint64        // address where process went to sleep
+	Nswap               int64         // (place holder)
+	Cnswap              int64         // (place holder)
+	ExitSignal          int           // signal to send to parent thread on exit
+	Processor           int           // which CPU the task is scheduled on
+	RtPriority          int64         // realtime priority
+	Policy              int64         // scheduling policy (man sched_setscheduler)
+	DelayacctBlkioTicks int64         // time spent waiting for block IO
 }
 
 //

--- a/util/structparser.go
+++ b/util/structparser.go
@@ -85,6 +85,12 @@ func parseField(field interface{}, line string) error {
 			return err
 		}
 		*field = jiffiesToTime(jiffies)
+	case *time.Duration:
+		jiffies, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			return nil
+		}
+		*field = jiffiesToDuration(jiffies)
 	default:
 		return fmt.Errorf("unsupported field type %T", field)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -36,7 +36,7 @@ import (
 import "C"
 
 //
-// systemStart() attempts to detect the system start time. 
+// systemStart() attempts to detect the system start time.
 //
 // It will attempt to fetch the system start time by parsing /proc/stat
 // look for the btime line, and converting that to an int64 value (the start
@@ -84,6 +84,11 @@ var GLOBAL_SYSTEM_START int64 = systemStart()
 //
 func jiffiesToTime(jiffies int64) time.Time {
 	ticks := C.sysconf(C._SC_CLK_TCK)
-	return time.Unix(GLOBAL_SYSTEM_START + jiffies/int64(ticks), 0)
+	return time.Unix(GLOBAL_SYSTEM_START+jiffies/int64(ticks), 0)
 }
 
+func jiffiesToDuration(jiffies int64) time.Duration {
+	ticks := C.sysconf(C._SC_CLK_TCK)
+	return time.Duration(jiffies / int64(ticks))
+
+}


### PR DESCRIPTION
so i made a pull requests i still have to test this, so if you prefer it would be better to pull it on a test branch and test it yourself, it should work it's a minor workaround and your code is easy to read and i followed the man for proc

i passed the files i was working on on go fmt as it's an automated process in my environment 

this should close this issue https://github.com/jandre/procfs/issues/8
